### PR TITLE
Second arrayQL parameter to be also a Callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,5 +26,5 @@ export interface QueryOptions<T> {
 
 export function arrayQL<T, R = any>(
   array: T[],
-  queryOptions: QueryOptions<T>
+  queryOptions: QueryOptions<T> | ((object: T) => QueryOptions<T>)
 ): R[];

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -26,5 +26,5 @@ export interface QueryOptions<T> {
 
 export function arrayQL<T, R = any>(
   array: T[],
-  queryOptions: QueryOptions<T>
+  queryOptions: QueryOptions<T> | ((object: T) => QueryOptions<T>)
 ): R[];

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,13 +51,14 @@ var __assign = (this && this.__assign) || function () {
     }
     function arrayQL(array, queryOptions) {
         var _a;
-        (_a = queryOptions.where) !== null && _a !== void 0 ? _a : (queryOptions.where = function () { return true; });
         var mappedArray = [];
         for (var _i = 0, array_1 = array; _i < array_1.length; _i++) {
             var object = array_1[_i];
-            if (!queryOptions.where(object))
+            var options = typeof queryOptions === "function" ? queryOptions(object) : queryOptions;
+            (_a = options.where) !== null && _a !== void 0 ? _a : (options.where = function () { return true; });
+            if (!options.where(object))
                 continue;
-            mappedArray.push(objectQL(object, queryOptions.keys));
+            mappedArray.push(objectQL(object, options.keys));
         }
         return mappedArray;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,13 +38,17 @@ function objectQL<T>(object: T, booleanKeys: BooleanKeys<T>) {
 
 export function arrayQL<T, R = any>(
   array: T[],
-  queryOptions: QueryOptions<T>
+  queryOptions: QueryOptions<T> | ((object: T) => QueryOptions<T>)
 ): R[] {
-  queryOptions.where ??= () => true;
   const mappedArray = [];
+
   for (const object of array) {
-    if (!queryOptions.where(object)) continue;
-    mappedArray.push(objectQL(object, queryOptions.keys));
+    const options =
+      typeof queryOptions === "function" ? queryOptions(object) : queryOptions;
+
+    options.where ??= () => true;
+    if (!options.where(object)) continue;
+    mappedArray.push(objectQL(object, options.keys));
   }
   return mappedArray;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,6 @@ export function arrayQL<T, R = any>(
   for (const object of array) {
     const options =
       typeof queryOptions === "function" ? queryOptions(object) : queryOptions;
-
     options.where ??= () => true;
     if (!options.where(object)) continue;
     mappedArray.push(objectQL(object, options.keys));

--- a/test/callback.test.ts
+++ b/test/callback.test.ts
@@ -1,0 +1,33 @@
+import { arrayQL } from "../src";
+import { unorganizedData } from "./mocks";
+
+describe("arrayql queries (map, filter)", () => {
+  it("should map same age user and their friends", () => {
+    const result = arrayQL(unorganizedData, ({ age }) => {
+      return {
+        keys: {
+          age: true,
+          friends: {
+            where: (friend) => age === friend.age,
+            keys: {
+              age: true,
+            },
+          },
+        },
+      };
+    });
+
+    const expectedResult = [
+      {
+        age: 18,
+        friends: [],
+      },
+      {
+        age: 30,
+        friends: [{ age: 30 }],
+      },
+    ];
+
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -16,6 +16,7 @@ export const unorganizedData = [
       {
         name: "jamelin",
         id: 1,
+        age: 20,
       },
     ],
   },
@@ -36,10 +37,12 @@ export const unorganizedData = [
       {
         name: "jamelão",
         id: 1,
+        age: 30,
       },
       {
         name: "rafael",
         id: 9,
+        age: 29,
       },
     ],
   },


### PR DESCRIPTION
What if I wanted to select the friends with same age as each user? To be done, the age should be available in the scope. So my resolution was to make the second parameter accepts also a function that returns the same thing, but now, it have access to each object in the array. But you can **only** check the values.

```js
const sameAgeFriends = arrayQL(users, ({ age }) => {
      return {
        keys: {
          age: true,
          friends: {
            where: (friend) => age === friend.age,
            keys: {
              age: true,
            },
          },
        },
      };
    });
```